### PR TITLE
Atualiza Airflow p/ versão 1.10.12 e as dependências necessárias

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,9 @@ python-dateutil==2.8.0
 numpy==1.17.0
 pandas==0.25.0
 alembic==1.2.1
-apache-airflow==1.10.4
-apispec==3.0.0
-attrs==19.1.0
+apache-airflow==1.10.12
+apispec==1.3.3
+attrs==19.3.0
 Babel==2.7.0
 boto3==1.7.84
 botocore==1.10.84
@@ -24,9 +24,9 @@ dill==0.2.9
 docutils==0.15.2
 dumb-init==1.2.2
 Flask==1.1.1
-Flask-Admin==1.5.3
-Flask-AppBuilder==1.13.1
-Flask-Babel==0.12.2
+Flask-Admin==1.5.4
+Flask-AppBuilder==2.3.4
+Flask-Babel==1.0.0
 Flask-Caching==1.3.3
 Flask-JWT-Extended==3.23.0
 Flask-Login==0.4.1
@@ -54,7 +54,7 @@ marshmallow-enum==1.5.1
 marshmallow-sqlalchemy==0.19.0
 ordereddict==1.1
 pendulum==1.4.4
-prison==0.1.0
+prison==0.1.3
 psutil==5.6.3
 psycopg2==2.7.7
 psycopg2-binary==2.8.3


### PR DESCRIPTION
A versão do apispec informada foi alterada pois ocorreu um erro em flask-appbuilder versão 2.3.4.
